### PR TITLE
Implement project skeleton for LegalBot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+TELEGRAM_TOKEN=changeme
+OPENROUTER_API_KEY=changeme
+POSTGRES_DSN=postgres://user:pass@postgres:5432/legalbot?sslmode=disable
+RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Binaries
+/bin/
+*.exe
+*.test
+
+# Output of go build
+bot
+worker
+prompt
+
+# Logs
+*.log
+
+# Environment
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+test:
+	go test ./... -race -count=1
+
+lint:
+	golangci-lint run
+
+docker-build:
+	docker build -f deploy/Dockerfile.bot -t legalbot/bot:local .

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # LegalBot
+
+LegalBot is a Telegram bot for assisting users with legal claims in Russia. It collects the user's problem, builds a "golden" prompt for OpenRouter, generates advice along with PDF and DOCX documents, and sends them back via Telegram.
+
+## Features
+- Commands: `/start`, `/help`, `/claim`, `/status`
+- Input text up to 8000 characters
+- Rate limit: 10 requests per minute per user
+- Generates PDF and DOCX versions of claim letters and lawsuits
+
+## Repository Structure
+```
+.
+├─ cmd/
+│  ├─ bot/      # Telegram webhook service
+│  ├─ prompt/   # Prompt builder gRPC service
+│  └─ worker/   # Task consumer
+├─ internal/
+│  ├─ telegram/    # Telegram SDK wrapper
+│  ├─ openrouter/  # REST client for OpenRouter
+│  ├─ prompt/      # Prompt templates
+│  └─ db/          # Postgres repositories
+├─ deploy/
+│  ├─ docker-compose.yml
+│  ├─ Dockerfile.bot
+│  ├─ Dockerfile.worker
+│  └─ Dockerfile.prompt
+├─ Makefile
+├─ SPEC.md        # Technical specification
+```
+
+## Running Locally
+```
+cp .env.example .env
+docker compose up --build
+```

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,175 @@
+Техническое задание
+
+КОНТЕКСТ
+• Назначение: Telegram-бот принимает юридическую проблему пользователя, собирает «золотой» промпт, вызывает OpenRouter и возвращает советы + PDF / DOCX претензий и исков.
+• SLA: не менее 95 % ответов за ≤ 10 с, 99 % без ошибок.
+• Языки: русский.
+ВЫСОКО-УРОВНЕВАЯ АРХИТЕКТУРА (ASCII-схема)
+User → Telegram API → Bot Service (Go Gin) ─┬─→ Prompt Builder gRPC
+│
+├─→ Redis (rate-limit)
+│
+├─→ RabbitMQ → Task Queue → Worker Pool (Go)
+│ │
+│ ├─→ OpenRouter REST
+│ └─→ Postgres
+└─→ wkhtmltopdf side-car (PDF)
+▲
+└───── Prometheus + Grafana + Loki (обзор).
+
+ПОТОК ЗАПРОСА
+Пользователь вводит /claim. Bot Service валидирует данные и кладёт задачу claim.create в RabbitMQ.
+Worker забирает задачу, вызывает Prompt Builder.Build(), собирает промпт.
+Выполняет POST https://openrouter.ai/v1/chat/completions.
+Результат (JSON) сохраняется в Postgres, создаётся PDF через wkhtmltopdf.
+Bot Service отправляет пользователю разъяснение + файл.
+ФУНКЦИОНАЛЬНЫЕ ТРЕБОВАНИЯ
+IDТребованиеКритерий приёмки
+F-01Команды /start, /help, /claim, /statusОтвет ≤ 200 мс
+F-02Приём текста до 8 000 символовБот режет/склеивает без потери данных
+F-03Генерация PDF и DOCX
+F-05Ограничение 10 запроса в минуту на пользователя11-й запрос отклонён Redis-bucket’ом
+НЕФУНКЦИОНАЛЬНЫЕ ТРЕБОВАНИЯ
+Производительность: P95 задержка Bot Service ≤ 400 мс
+Масштабирование: Worker Pool горизонтально до 100 запросов/с
+Безопасность: TLS 1.3, проверка X-Telegram-Bot-Api-Secret-Token, секреты в Vault
+Контейнеры: multi-stage, итоговый образ < 300 MB
+Покрытие тестами: ≥ 90 % unit, ≥ 70 % интеграционных
+
+СТРУКТУРА РЕПОЗИТОРИЯ
+.
+├─ cmd/
+│ ├─ bot/ (веб-хуки Telegram)
+│ ├─ prompt/ (gRPC-сервис промптов)
+│ └─ worker/ (консьюмер задач)
+├─ internal/
+│ ├─ telegram/ (SDK-обёртка)
+│ ├─ openrouter/ (REST-клиент)
+│ ├─ prompt/ (шаблоны)
+│ └─ db/ (Postgres-репозитории)
+├─ deploy/
+│ ├─ docker-compose.yml
+│ ├─ Dockerfile.bot
+│ ├─ Dockerfile.worker
+│ └─ Dockerfile.prompt
+├─ .github/workflows/deploy.yml
+├─ Makefile
+├─ README.md
+└─ SPEC.md (этот файл)
+
+ШАБЛОН «ЗОЛОТОГО» ПРОМПТА (пример)
+SYSTEM:
+You are a licensed Russian attorney with 15+ years practice…
+CONTEXT:
+– Jurisdiction: Russian Federation
+– Date: {{ .Date }}
+– Law excerpts: {{ .Laws }}
+USER_QUESTION:
+{{ .UserText }}
+TASKS:
+Qualify the issue.
+Advise step-by-step actions.
+Draft claim letter (Markdown).
+Draft lawsuit (Markdown).
+STYLE: Russian, formal, references to articles.
+OUTPUT_FORMAT: JSON with keys [advice_md, claim_md, lawsuit_md]
+
+GITHUB ACTIONS — АВТОМАТИЧЕСКОЕ ОБНОВЛЕНИЕ
+Файл .github/workflows/deploy.yml:
+
+name: CI/CD
+on:
+push:
+branches: [ main ]
+
+jobs:
+build-and-deploy:
+runs-on: ubuntu-latest
+env:
+REGISTRY: ghcr.io
+IMAGE_NAME: ${{ github.repository }}-bot
+steps:
+- uses: actions/checkout@v4
+- uses: actions/setup-go@v5
+with:
+go-version: '1.22'
+  - name: Run tests  
+    run: make test  
+
+  - name: Build Docker image  
+    run: docker build -f deploy/Dockerfile.bot -t $REGISTRY/$IMAGE_NAME:${{ github.sha }} .  
+
+  - name: Push to GHCR  
+    uses: docker/login-action@v3  
+    with:  
+      registry: ${{ env.REGISTRY }}  
+      username: ${{ github.actor }}  
+      password: ${{ secrets.GITHUB_TOKEN }}  
+
+  - run: docker push $REGISTRY/$IMAGE_NAME:${{ github.sha }}  
+
+  - name: Deploy via SSH & docker compose  
+    uses: appleboy/ssh-action@v1.0.0  
+    with:  
+      host: ${{ secrets.SERVER_IP }}  
+      username: deploy  
+      key: ${{ secrets.SERVER_SSH_KEY }}  
+      script: |  
+        cd /opt/legalbot  
+        docker pull $REGISTRY/$IMAGE_NAME:${{ github.sha }}  
+        docker compose down  
+        IMAGE_TAG=${{ github.sha }} docker compose up -d
+
+ВЫДЕРЖКА docker-compose.yml
+version: "3.9"
+services:
+bot:
+image: ghcr.io/owner/legalbot-bot:${IMAGE_TAG:-latest}
+env_file:
+- .env
+depends_on:
+- postgres
+- rabbitmq
+restart: always
+
+prompt:
+image: ghcr.io/owner/legalbot-prompt:${IMAGE_TAG:-latest}
+env_file: [.env]
+restart: always
+
+worker:
+image: ghcr.io/owner/legalbot-worker:${IMAGE_TAG:-latest}
+env_file: [.env]
+depends_on: [rabbitmq, postgres]
+restart: always
+
+postgres:
+image: postgres:16
+environment:
+POSTGRES_PASSWORD: legalbot
+volumes: [db_data:/var/lib/postgresql/data]
+
+rabbitmq:
+image: rabbitmq:3-management
+
+grafana:
+image: grafana/grafana
+
+volumes:
+db_data:
+
+MAKEFILE (основные цели)
+test:
+ go test ./... -race -count=1
+
+lint:
+ golangci-lint run
+
+docker-build:
+ docker build -f deploy/Dockerfile.bot -t legalbot/bot:local .
+
+README — ЗАПУСК ЛОКАЛЬНО
+git clone https://github.com/owner/legalbot.git
+cd legalbot
+cp .env.example .env
+docker compose up --build

--- a/deploy/Dockerfile.bot
+++ b/deploy/Dockerfile.bot
@@ -1,0 +1,8 @@
+FROM golang:1.22 AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o bot ./cmd/bot
+
+FROM gcr.io/distroless/base
+COPY --from=builder /app/bot /bot
+CMD ["/bot"]

--- a/deploy/Dockerfile.prompt
+++ b/deploy/Dockerfile.prompt
@@ -1,0 +1,8 @@
+FROM golang:1.22 AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o prompt ./cmd/prompt
+
+FROM gcr.io/distroless/base
+COPY --from=builder /app/prompt /prompt
+CMD ["/prompt"]

--- a/deploy/Dockerfile.worker
+++ b/deploy/Dockerfile.worker
@@ -1,0 +1,8 @@
+FROM golang:1.22 AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o worker ./cmd/worker
+
+FROM gcr.io/distroless/base
+COPY --from=builder /app/worker /worker
+CMD ["/worker"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+services:
+  bot:
+    image: ghcr.io/owner/legalbot-bot:${IMAGE_TAG:-latest}
+    env_file:
+      - .env
+    depends_on:
+      - postgres
+      - rabbitmq
+    restart: always
+
+  prompt:
+    image: ghcr.io/owner/legalbot-prompt:${IMAGE_TAG:-latest}
+    env_file:
+      - .env
+    restart: always
+
+  worker:
+    image: ghcr.io/owner/legalbot-worker:${IMAGE_TAG:-latest}
+    env_file:
+      - .env
+    depends_on:
+      - rabbitmq
+      - postgres
+    restart: always
+
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: legalbot
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  rabbitmq:
+    image: rabbitmq:3-management
+
+  grafana:
+    image: grafana/grafana
+
+volumes:
+  db_data:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module legalbot
+
+go 1.23.8

--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -1,0 +1,11 @@
+package db
+
+// Repository provides access to Postgres.
+type Repository struct {
+    // TODO: add connection pool
+}
+
+func New(conn string) (*Repository, error) {
+    // TODO: connect to database
+    return &Repository{}, nil
+}

--- a/internal/openrouter/client.go
+++ b/internal/openrouter/client.go
@@ -1,0 +1,18 @@
+package openrouter
+
+import "context"
+
+// Client calls the OpenRouter API.
+type Client struct{
+    APIKey string
+}
+
+func New(apiKey string) *Client {
+    return &Client{APIKey: apiKey}
+}
+
+// ChatCompletion sends a prompt and returns the response.
+func (c *Client) ChatCompletion(ctx context.Context, prompt string) (string, error) {
+    // TODO: implement HTTP call to OpenRouter
+    return "", nil
+}

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -1,0 +1,20 @@
+package telegram
+
+import "net/http"
+
+// Client is a minimal Telegram Bot API client.
+type Client struct {
+Token string
+HTTP  *http.Client
+}
+
+// New creates a new client.
+func New(token string) *Client {
+return &Client{Token: token, HTTP: http.DefaultClient}
+}
+
+// SendMessage sends a text message.
+func (c *Client) SendMessage(chatID int64, text string) error {
+// TODO: implement actual API call
+return nil
+}


### PR DESCRIPTION
## Summary
- initialize repo with Go module and directory structure
- add basic README and SPEC
- create Dockerfiles and docker-compose for services
- add skeleton sources for bot, worker, prompt services and internal packages
- provide example environment file and Makefile

## Testing
- `make test` *(fails: missing Go dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683ac38c8e248328a15dc47ac353a7ce