### PR TITLE
Implement OpenRouter client

### DIFF
--- a/internal/openrouter/client.go
+++ b/internal/openrouter/client.go
@@ -1,18 +1,47 @@
 package openrouter
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
 
 // Client calls the OpenRouter API.
-type Client struct{
-    APIKey string
+type Client struct {
+	APIKey string
 }
 
 func New(apiKey string) *Client {
-    return &Client{APIKey: apiKey}
+	return &Client{APIKey: apiKey}
 }
+
+var endpoint = "https://openrouter.ai/v1/chat/completions"
 
 // ChatCompletion sends a prompt and returns the response.
 func (c *Client) ChatCompletion(ctx context.Context, prompt string) (string, error) {
-    // TODO: implement HTTP call to OpenRouter
-    return "", nil
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewBufferString(prompt))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return "", fmt.Errorf("openrouter: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return string(body), nil
 }

--- a/internal/openrouter/client_test.go
+++ b/internal/openrouter/client_test.go
@@ -1,0 +1,59 @@
+package openrouter
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestChatCompletionSuccess(t *testing.T) {
+	wantBody := "{\"ok\":true}"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.Write([]byte(wantBody))
+	}))
+	defer srv.Close()
+
+	old := endpoint
+	endpoint = srv.URL
+	defer func() { endpoint = old }()
+
+	c := New("Bearer test")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	body, err := c.ChatCompletion(ctx, "{}")
+	if err != nil {
+		t.Fatalf("ChatCompletion returned error: %v", err)
+	}
+	if body != wantBody {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestChatCompletionError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	old := endpoint
+	endpoint = srv.URL
+	defer func() { endpoint = old }()
+
+	c := New("key")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := c.ChatCompletion(ctx, "{}")
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected error containing 'boom', got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add HTTP POST logic for OpenRouter API
- include Authorization header and respect context timeout
- return response body and propagate errors
- add unit tests covering success and failure cases

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683aec1a61c483289f5be4bb17914a33