### PR TITLE
Implement Telegram SendMessage

### DIFF
--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -1,20 +1,51 @@
 package telegram
 
-import "net/http"
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
 
 // Client is a minimal Telegram Bot API client.
 type Client struct {
-Token string
-HTTP  *http.Client
+	Token string
+	HTTP  *http.Client
 }
 
 // New creates a new client.
 func New(token string) *Client {
-return &Client{Token: token, HTTP: http.DefaultClient}
+	return &Client{Token: token, HTTP: &http.Client{Timeout: 10 * time.Second}}
 }
+
+var apiURL = "https://api.telegram.org"
 
 // SendMessage sends a text message.
 func (c *Client) SendMessage(chatID int64, text string) error {
-// TODO: implement actual API call
-return nil
+	u := fmt.Sprintf("%s/bot%s/sendMessage", apiURL, c.Token)
+	data := url.Values{}
+	data.Set("chat_id", strconv.FormatInt(chatID, 10))
+	data.Set("text", text)
+
+	req, err := http.NewRequest(http.MethodPost, u, strings.NewReader(data.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("telegram: status %d: %s", resp.StatusCode, string(b))
+	}
+
+	return nil
 }

--- a/internal/telegram/client_test.go
+++ b/internal/telegram/client_test.go
@@ -1,0 +1,55 @@
+package telegram
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSendMessageSuccess(t *testing.T) {
+	chatID := int64(123)
+	text := "hi"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/botTOKEN/sendMessage" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if r.Form.Get("chat_id") != "123" || r.Form.Get("text") != text {
+			t.Errorf("unexpected form: %v", r.Form)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	old := apiURL
+	apiURL = srv.URL
+	defer func() { apiURL = old }()
+
+	c := New("TOKEN")
+	if err := c.SendMessage(chatID, text); err != nil {
+		t.Fatalf("SendMessage returned error: %v", err)
+	}
+}
+
+func TestSendMessageError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusTeapot)
+	}))
+	defer srv.Close()
+
+	old := apiURL
+	apiURL = srv.URL
+	defer func() { apiURL = old }()
+
+	c := New("TOKEN")
+	err := c.SendMessage(1, "hi")
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected error containing boom, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- use a dedicated HTTP client with a timeout
- add real POST logic to SendMessage
- fail on non-success responses
- cover Telegram client with httptest

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683aece9d6488328aeb4800f04814506