### PR TITLE
Enhance deployment with Vault secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: CI/CD
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}-bot
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Run tests
+        run: make test
+
+      - name: Build Docker image
+        run: docker build -f deploy/Dockerfile.bot -t $REGISTRY/$IMAGE_NAME:${{ github.sha }} .
+
+      - name: Push to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: docker push $REGISTRY/$IMAGE_NAME:${{ github.sha }}
+
+      - name: Read secrets from Vault
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/legalbot SERVER_IP;
+            secret/data/legalbot SERVER_SSH_KEY;
+
+      - name: Deploy via SSH & docker compose
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ env.SERVER_IP }}
+          username: deploy
+          key: ${{ env.SERVER_SSH_KEY }}
+          script: |
+            cd /opt/legalbot
+            docker pull $REGISTRY/$IMAGE_NAME:${{ github.sha }}
+            docker compose down
+            IMAGE_TAG=${{ github.sha }} docker compose up -d

--- a/README.md
+++ b/README.md
@@ -35,3 +35,14 @@ LegalBot is a Telegram bot for assisting users with legal claims in Russia. It c
 cp .env.example .env
 docker compose up --build
 ```
+
+## Deployment
+Automated deployment is handled by GitHub Actions. Secrets such as the server
+IP address and SSH key are stored in HashiCorp Vault. The workflow reads these
+values using `hashicorp/vault-action@v2` and then performs an SSH deployment via
+`appleboy/ssh-action`.
+
+Configure Vault with `SERVER_IP` and `SERVER_SSH_KEY` keys under the
+`secret/data/legalbot` path. Provide `VAULT_ADDR`, `VAULT_ROLE_ID` and
+`VAULT_SECRET_ID` as GitHub repository secrets so the workflow can fetch the
+credentials during the deploy job.


### PR DESCRIPTION
## Summary
- add GH Actions workflow for CI/CD
- fetch secrets from HashiCorp Vault before deployment
- document Vault-based deployment
- update SPEC to match new workflow

## Testing
- `go test ./...` *(fails: missing go.sum entry)*

------
https://chatgpt.com/codex/tasks/task_e_683af5d029848328a26effd7014d004a