### PR TITLE
Configure OpenRouter client timeout

### DIFF
--- a/internal/openrouter/client.go
+++ b/internal/openrouter/client.go
@@ -6,16 +6,42 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"time"
 )
 
 // Client calls the OpenRouter API.
 type Client struct {
 	APIKey string
+	HTTP   *http.Client
 }
 
-// New creates a new OpenRouter client using the provided API key.
+// New creates a new OpenRouter client using the provided API key. Timeout can be
+// customized via the OPENROUTER_TIMEOUT environment variable (e.g. "20s").
+// Default timeout is 15 seconds.
 func New(apiKey string) *Client {
-	return &Client{APIKey: apiKey}
+	timeout := 15 * time.Second
+	if v := os.Getenv("OPENROUTER_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			timeout = d
+		}
+	}
+	return &Client{APIKey: apiKey, HTTP: &http.Client{Timeout: timeout}}
+}
+
+// WithTimeout allows customizing HTTP client timeout when creating a new
+// client.
+func WithTimeout(d time.Duration) func(*Client) {
+	return func(c *Client) { c.HTTP.Timeout = d }
+}
+
+// NewWithOptions creates a new client and applies given options.
+func NewWithOptions(apiKey string, opts ...func(*Client)) *Client {
+	c := New(apiKey)
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 var endpoint = "https://openrouter.ai/v1/chat/completions"
@@ -29,7 +55,7 @@ func (c *Client) ChatCompletion(ctx context.Context, prompt string) (string, err
 	req.Header.Set("Authorization", c.APIKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.HTTP.Do(req)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- add configurable http.Client for OpenRouter requests
- default to 15s timeout and allow override via OPENROUTER_TIMEOUT or option

## Testing
- `go test ./internal/openrouter`
- `make test` *(fails: missing go.sum entries due to no network access)*

------
https://chatgpt.com/codex/tasks/task_e_683af91c2d6883289519a2e1116082c8