### PR TITLE
Add configurable endpoint to OpenRouter client

### DIFF
--- a/internal/openrouter/client_test.go
+++ b/internal/openrouter/client_test.go
@@ -23,11 +23,7 @@ func TestChatCompletionSuccess(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	old := endpoint
-	endpoint = srv.URL
-	defer func() { endpoint = old }()
-
-	c := New("Bearer test")
+	c := NewWithOptions("Bearer test", WithEndpoint(srv.URL))
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	body, err := c.ChatCompletion(ctx, "{}")
@@ -45,11 +41,7 @@ func TestChatCompletionError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	old := endpoint
-	endpoint = srv.URL
-	defer func() { endpoint = old }()
-
-	c := New("key")
+	c := NewWithOptions("key", WithEndpoint(srv.URL))
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	_, err := c.ChatCompletion(ctx, "{}")


### PR DESCRIPTION
## Summary
- add `Endpoint` field to `Client`
- support `OPENROUTER_ENDPOINT` env var and `WithEndpoint` option
- update tests for endpoint configuration

## Testing
- `go test ./...` *(fails: missing go.sum entry)*

------
https://chatgpt.com/codex/tasks/task_e_683afa1a32748328af2b2a8fd8b17c35