### PR TITLE
Add context to telegram client

### DIFF
--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -1,6 +1,7 @@
 package telegram
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,13 +25,13 @@ func New(token string) *Client {
 var apiURL = "https://api.telegram.org"
 
 // SendMessage sends a text message.
-func (c *Client) SendMessage(chatID int64, text string) error {
+func (c *Client) SendMessage(ctx context.Context, chatID int64, text string) error {
 	u := fmt.Sprintf("%s/bot%s/sendMessage", apiURL, c.Token)
 	data := url.Values{}
 	data.Set("chat_id", strconv.FormatInt(chatID, 10))
 	data.Set("text", text)
 
-	req, err := http.NewRequest(http.MethodPost, u, strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, strings.NewReader(data.Encode()))
 	if err != nil {
 		return err
 	}

--- a/internal/telegram/client_test.go
+++ b/internal/telegram/client_test.go
@@ -1,10 +1,12 @@
 package telegram
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSendMessageSuccess(t *testing.T) {
@@ -32,7 +34,9 @@ func TestSendMessageSuccess(t *testing.T) {
 	defer func() { apiURL = old }()
 
 	c := New("TOKEN")
-	if err := c.SendMessage(chatID, text); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := c.SendMessage(ctx, chatID, text); err != nil {
 		t.Fatalf("SendMessage returned error: %v", err)
 	}
 }
@@ -48,7 +52,9 @@ func TestSendMessageError(t *testing.T) {
 	defer func() { apiURL = old }()
 
 	c := New("TOKEN")
-	err := c.SendMessage(1, "hi")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := c.SendMessage(ctx, 1, "hi")
 	if err == nil || !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("expected error containing boom, got %v", err)
 	}


### PR DESCRIPTION
## Summary
- support context for telegram messaging
- update telegram tests

## Testing
- `go test ./...` *(fails: missing go.sum entry for github.com/jackc/pgx/v5/pgxpool)*

------
https://chatgpt.com/codex/tasks/task_e_683afae6060c83288491185015f8543e