### PR TITLE
Add structured logging and wrap errors

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -2,18 +2,24 @@ package main
 
 import (
 	"flag"
-	"log"
+	"log/slog"
 	"net/http"
+	"os"
 )
 
 func main() {
 	addr := flag.String("listen", ":8080", "listen address")
 	flag.Parse()
 
-	log.Printf("starting bot on %s", *addr)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+	logger.Info("starting bot", "addr", *addr)
 	if err := http.ListenAndServe(*addr, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if reqID := r.Header.Get("X-Request-ID"); reqID != "" {
+			logger.Info("ping", "request_id", reqID)
+		}
 		w.Write([]byte("ok"))
 	})); err != nil {
-		log.Fatal(err)
+		logger.Error("server error", "err", err)
 	}
 }

--- a/cmd/prompt/main.go
+++ b/cmd/prompt/main.go
@@ -2,18 +2,24 @@ package main
 
 import (
 	"flag"
-	"log"
+	"log/slog"
 	"net/http"
+	"os"
 )
 
 func main() {
 	addr := flag.String("listen", ":8090", "listen address")
 	flag.Parse()
 
-	log.Printf("starting prompt service on %s", *addr)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+	logger.Info("starting prompt service", "addr", *addr)
 	if err := http.ListenAndServe(*addr, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if reqID := r.Header.Get("X-Request-ID"); reqID != "" {
+			logger.Info("ping", "request_id", reqID)
+		}
 		w.Write([]byte("ok"))
 	})); err != nil {
-		log.Fatal(err)
+		logger.Error("server error", "err", err)
 	}
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"flag"
-	"log"
+	"log/slog"
+	"os"
 	"time"
 )
 
@@ -10,8 +11,10 @@ func main() {
 	queue := flag.String("queue", "amqp://guest:guest@localhost:5672/", "AMQP URL")
 	flag.Parse()
 
-	log.Printf("starting worker, queue=%s", *queue)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+	logger.Info("starting worker", "queue", *queue)
 	for range time.Tick(time.Second) {
-		log.Println("worker tick")
+		logger.Info("worker tick")
 	}
 }

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -13,13 +14,19 @@ import (
 
 // Client is a minimal Telegram Bot API client.
 type Client struct {
-	Token string
-	HTTP  *http.Client
+	Token  string
+	HTTP   *http.Client
+	Logger *slog.Logger
 }
 
 // New creates a new client.
 func New(token string) *Client {
-	return &Client{Token: token, HTTP: &http.Client{Timeout: 10 * time.Second}}
+	return &Client{Token: token, HTTP: &http.Client{Timeout: 10 * time.Second}, Logger: slog.Default()}
+}
+
+// WithLogger sets a custom logger when creating a new client.
+func WithLogger(l *slog.Logger) func(*Client) {
+	return func(c *Client) { c.Logger = l }
 }
 
 var apiURL = "https://api.telegram.org"
@@ -33,19 +40,27 @@ func (c *Client) SendMessage(ctx context.Context, chatID int64, text string) err
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, strings.NewReader(data.Encode()))
 	if err != nil {
-		return err
+		return fmt.Errorf("new request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
+	if c.Logger != nil {
+		c.Logger.Info("send telegram message", "chat_id", chatID)
+	}
+
 	resp, err := c.HTTP.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("send message: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= http.StatusBadRequest {
 		b, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("telegram: status %d: %s", resp.StatusCode, string(b))
+	}
+
+	if c.Logger != nil {
+		c.Logger.Info("telegram message sent", "chat_id", chatID)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- add slog-based logging to command binaries
- implement structured logging and error wrapping in internal clients
- log request or chat IDs for better tracing

## Testing
- `go test ./...` *(fails: missing go.sum entry, network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_683afd96a774832897869c19c90c52b3