### PR TITLE
Add lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+version: 2
+linters:
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+run:
+  timeout: 5m

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ cp .env.example .env
 docker compose up --build
 ```
 
+## Linting
+```bash
+make lint
+```
+Uses `golangci-lint` with settings in `.golangci.yml`.
+
 ## Deployment
 Automated deployment is handled by GitHub Actions. Secrets such as the server
 IP address and SSH key are stored in HashiCorp Vault. The workflow reads these


### PR DESCRIPTION
## Summary
- add `.golangci.yml` for govet, errcheck and staticcheck
- document linting workflow in README

## Testing
- `make lint` *(fails: Error return value of `w.Write` is not checked)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_683b0212e01883289ffeaacbbdfda551