### PR TITLE
Add history retrieval and deletion commands

### DIFF
--- a/cmd/bot/handler.go
+++ b/cmd/bot/handler.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"fmt"
+
+	"legalbot/internal/db"
 )
 
 // langPref stores user language preferences.
@@ -32,6 +35,16 @@ type ResultSaver interface {
 	SaveResult(ctx context.Context, chatID int64, data string) (int64, error)
 }
 
+type ResultFetcher interface {
+	RecentResults(ctx context.Context, chatID int64, limit int) ([]db.Result, error)
+}
+
+type HistoryDeleter interface {
+	DeleteHistory(ctx context.Context, chatID int64) error
+}
+
+var docsBaseURL = "https://example.com/docs"
+
 // handleClaim processes user claim: sends prompt to OpenRouter, saves the result and sends it back to Telegram.
 func handleClaim(ctx context.Context, tg TelegramSender, or OpenRouterClient, repo ResultSaver, chatID int64, prompt string) error {
 	resp, err := or.ChatCompletion(ctx, prompt)
@@ -45,4 +58,27 @@ func handleClaim(ctx context.Context, tg TelegramSender, or OpenRouterClient, re
 		return err
 	}
 	return nil
+}
+
+// handleRecent sends links to recent documents for a chat.
+func handleRecent(ctx context.Context, tg TelegramSender, repo ResultFetcher, chatID int64) error {
+	res, err := repo.RecentResults(ctx, chatID, 5)
+	if err != nil {
+		return err
+	}
+	for _, r := range res {
+		link := fmt.Sprintf("%s/%d", docsBaseURL, r.ID)
+		if err := tg.SendMessage(ctx, chatID, link); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// handleDelete removes chat history.
+func handleDelete(ctx context.Context, tg TelegramSender, repo HistoryDeleter, chatID int64) error {
+	if err := repo.DeleteHistory(ctx, chatID); err != nil {
+		return err
+	}
+	return tg.SendMessage(ctx, chatID, "history deleted")
 }

--- a/stub/pgxv5/pgxpool/pgxpool.go
+++ b/stub/pgxv5/pgxpool/pgxpool.go
@@ -3,6 +3,7 @@ package pgxpool
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -62,12 +63,89 @@ func (p *Pool) QueryRow(ctx context.Context, query string, args ...interface{}) 
 func (p *Pool) Exec(ctx context.Context, query string, args ...interface{}) (CommandTag, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "DELETE") {
-		id := args[0].(int64)
-		delete(p.rows, id)
+	q := strings.ToUpper(strings.TrimSpace(query))
+	if strings.HasPrefix(q, "DELETE") {
+		if strings.Contains(q, "CHAT_ID") {
+			chatID := args[0].(int64)
+			for id, r := range p.rows {
+				if r.chatID == chatID {
+					delete(p.rows, id)
+				}
+			}
+		} else {
+			id := args[0].(int64)
+			delete(p.rows, id)
+		}
 	}
 	return CommandTag{}, nil
 }
+
+func (p *Pool) Query(ctx context.Context, query string, args ...interface{}) (Rows, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	q := strings.ToUpper(strings.TrimSpace(query))
+	if strings.HasPrefix(q, "SELECT") && strings.Contains(q, "CHAT_ID") {
+		chatID := args[0].(int64)
+		limit := args[1].(int)
+		type pair struct {
+			id   int64
+			data rowData
+		}
+		var res []pair
+		for id, r := range p.rows {
+			if r.chatID == chatID {
+				res = append(res, pair{id: id, data: r})
+			}
+		}
+		sort.Slice(res, func(i, j int) bool { return res[i].data.createdAt.After(res[j].data.createdAt) })
+		if limit > len(res) {
+			limit = len(res)
+		}
+		vals := make([][]interface{}, 0, limit)
+		for i := 0; i < limit; i++ {
+			r := res[i]
+			vals = append(vals, []interface{}{r.id, r.data.chatID, r.data.data, r.data.createdAt})
+		}
+		return Rows{vals: vals}, nil
+	}
+	return Rows{}, nil
+}
+
+type Rows struct {
+	vals [][]interface{}
+	idx  int
+	err  error
+}
+
+func (r *Rows) Next() bool {
+	if r.idx >= len(r.vals) {
+		return false
+	}
+	return true
+}
+
+func (r *Rows) Scan(dest ...interface{}) error {
+	if r.idx >= len(r.vals) {
+		return errors.New("no row")
+	}
+	row := r.vals[r.idx]
+	for i := range dest {
+		switch d := dest[i].(type) {
+		case *int64:
+			*d = row[i].(int64)
+		case *string:
+			*d = row[i].(string)
+		case *time.Time:
+			*d = row[i].(time.Time)
+		}
+	}
+	r.idx++
+	return nil
+}
+
+func (r *Rows) Err() error { return r.err }
+
+func (r *Rows) Close() {}
 
 func (p *Pool) Close() {}
 


### PR DESCRIPTION
## Summary
- add `RecentResults` and `DeleteHistory` repo methods
- support new queries in pgxpool test stub
- extend bot handler with `/delete` and history retrieval helpers
- update handler tests for new commands
- add unit tests for repository recent and delete operations

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683b03d5ee0c8328a851a594770595fd