### PR TITLE
Add Telegram webhook secret token check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 TELEGRAM_TOKEN=changeme
+TELEGRAM_SECRET_TOKEN=changeme
 OPENROUTER_API_KEY=changeme
 POSTGRES_DSN=postgres://user:pass@postgres:5432/legalbot?sslmode=disable
 RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ LegalBot is a Telegram bot for assisting users with legal claims in Russia. It c
 ## Running Locally
 ```
 cp .env.example .env
+# set TELEGRAM_SECRET_TOKEN to the value configured in your bot settings
 docker compose up --build
 ```
 

--- a/cmd/bot/handler_test.go
+++ b/cmd/bot/handler_test.go
@@ -3,7 +3,11 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
+	"net/http"
 	"testing"
+
+	"log/slog"
 
 	"legalbot/internal/db"
 )
@@ -148,5 +152,23 @@ func TestHandleDelete(t *testing.T) {
 	}
 	if repo.chatID != 20 {
 		t.Fatalf("repo not called")
+	}
+}
+
+func TestCheckSecretTokenMatch(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodPost, "/", nil)
+	r.Header.Set("X-Telegram-Bot-Api-Secret-Token", "a")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if !checkSecretToken(r, "a", logger) {
+		t.Fatalf("expected token match")
+	}
+}
+
+func TestCheckSecretTokenMismatch(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodPost, "/", nil)
+	r.Header.Set("X-Telegram-Bot-Api-Secret-Token", "bad")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if checkSecretToken(r, "good", logger) {
+		t.Fatalf("expected mismatch")
 	}
 }

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -13,8 +13,16 @@ func main() {
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	slog.SetDefault(logger)
+	secret := os.Getenv("TELEGRAM_SECRET_TOKEN")
+	if secret == "" {
+		logger.Warn("TELEGRAM_SECRET_TOKEN not set")
+	}
 	logger.Info("starting bot", "addr", *addr)
 	if err := http.ListenAndServe(*addr, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !checkSecretToken(r, secret, logger) {
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
 		if reqID := r.Header.Get("X-Request-ID"); reqID != "" {
 			logger.Info("ping", "request_id", reqID)
 		}


### PR DESCRIPTION
## Summary
- validate `X-Telegram-Bot-Api-Secret-Token` against `TELEGRAM_SECRET_TOKEN`
- log invalid attempts and warn if env var missing
- add tests for secret token checker
- document the new variable in README and `.env.example`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683b05559f6c83289ce21adf45de883e