### PR TITLE
Introduce shared temporary error constant

### DIFF
--- a/cmd/bot/handler.go
+++ b/cmd/bot/handler.go
@@ -52,6 +52,8 @@ type RateLimiter interface {
 
 var docsBaseURL = "https://example.com/docs"
 
+const temporaryErrorMsg = "temporary error, please try again later"
+
 // checkSecretToken validates the Telegram secret token header.
 // It returns true if the header matches the expected token.
 func checkSecretToken(r *http.Request, expected string, l *slog.Logger) bool {
@@ -79,14 +81,14 @@ func handleClaim(ctx context.Context, tg TelegramSender, or OpenRouterClient, re
 	resp, err := or.ChatCompletion(ctx, prompt)
 	if err != nil {
 		slog.Error("openrouter", "err", err)
-		if sendErr := tg.SendMessage(ctx, chatID, "temporary error, please try again later"); sendErr != nil {
+		if sendErr := tg.SendMessage(ctx, chatID, temporaryErrorMsg); sendErr != nil {
 			return sendErr
 		}
 		return nil
 	}
 	if _, err := repo.SaveResult(ctx, chatID, resp); err != nil {
 		slog.Error("db save", "err", err)
-		if sendErr := tg.SendMessage(ctx, chatID, "temporary error, please try again later"); sendErr != nil {
+		if sendErr := tg.SendMessage(ctx, chatID, temporaryErrorMsg); sendErr != nil {
 			return sendErr
 		}
 		return nil
@@ -102,7 +104,7 @@ func handleRecent(ctx context.Context, tg TelegramSender, repo ResultFetcher, ch
 	res, err := repo.RecentResults(ctx, chatID, 5)
 	if err != nil {
 		slog.Error("db recent", "err", err)
-		if sendErr := tg.SendMessage(ctx, chatID, "temporary error, please try again later"); sendErr != nil {
+		if sendErr := tg.SendMessage(ctx, chatID, temporaryErrorMsg); sendErr != nil {
 			return sendErr
 		}
 		return nil
@@ -120,7 +122,7 @@ func handleRecent(ctx context.Context, tg TelegramSender, repo ResultFetcher, ch
 func handleDelete(ctx context.Context, tg TelegramSender, repo HistoryDeleter, chatID int64) error {
 	if err := repo.DeleteHistory(ctx, chatID); err != nil {
 		slog.Error("db delete", "err", err)
-		if sendErr := tg.SendMessage(ctx, chatID, "temporary error, please try again later"); sendErr != nil {
+		if sendErr := tg.SendMessage(ctx, chatID, temporaryErrorMsg); sendErr != nil {
 			return sendErr
 		}
 		return nil

--- a/cmd/bot/handler_test.go
+++ b/cmd/bot/handler_test.go
@@ -97,7 +97,7 @@ func TestHandleClaimOpenRouterError(t *testing.T) {
 	if repo.data != "" {
 		t.Errorf("repo should not be called")
 	}
-	if tg.text != "temporary error, please try again later" {
+	if tg.text != temporaryErrorMsg {
 		t.Errorf("unexpected message %s", tg.text)
 	}
 }
@@ -113,7 +113,7 @@ func TestHandleClaimRepoError(t *testing.T) {
 	if repo.chatID != 1 || repo.data != "x" {
 		t.Errorf("repo not called correctly")
 	}
-	if tg.text != "temporary error, please try again later" {
+	if tg.text != temporaryErrorMsg {
 		t.Errorf("unexpected message %s", tg.text)
 	}
 }
@@ -162,7 +162,7 @@ func TestHandleRecentRepoError(t *testing.T) {
 	if err := handleRecent(context.Background(), tg, repo, 10); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if tg.text != "temporary error, please try again later" {
+	if tg.text != temporaryErrorMsg {
 		t.Errorf("unexpected message %s", tg.text)
 	}
 }
@@ -187,7 +187,7 @@ func TestHandleDeleteRepoError(t *testing.T) {
 	if err := handleDelete(context.Background(), tg, repo, 99); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if tg.text != "temporary error, please try again later" {
+	if tg.text != temporaryErrorMsg {
 		t.Errorf("unexpected message %s", tg.text)
 	}
 }


### PR DESCRIPTION
## Summary
- add `temporaryErrorMsg` constant for repeated reply
- use the constant in `handleClaim`, `handleRecent`, and `handleDelete`
- update tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683b2f55c4348328af17bdb368915802