### PR TITLE
Add DOCS_BASE_URL env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ TELEGRAM_SECRET_TOKEN=changeme
 OPENROUTER_API_KEY=changeme
 POSTGRES_DSN=postgres://user:pass@postgres:5432/legalbot?sslmode=disable
 RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
+DOCS_BASE_URL=https://example.com/docs

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ cp .env.example .env
 docker compose up --build
 ```
 
+`DOCS_BASE_URL` can be used to customize the base URL for document links.
+
 ## Linting
 ```bash
 make lint

--- a/cmd/bot/handler.go
+++ b/cmd/bot/handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 
 	"legalbot/internal/db"
 )
@@ -50,7 +51,16 @@ type RateLimiter interface {
 	Allow(chatID int64) bool
 }
 
-var docsBaseURL = "https://example.com/docs"
+// loadDocsBaseURL returns the documentation base URL using the DOCS_BASE_URL
+// environment variable if set, otherwise falling back to the default value.
+func loadDocsBaseURL() string {
+	if v := os.Getenv("DOCS_BASE_URL"); v != "" {
+		return v
+	}
+	return "https://example.com/docs"
+}
+
+var docsBaseURL = loadDocsBaseURL()
 
 const temporaryErrorMsg = "temporary error, please try again later"
 

--- a/cmd/bot/handler_test.go
+++ b/cmd/bot/handler_test.go
@@ -144,7 +144,8 @@ func TestLangForDefault(t *testing.T) {
 func TestHandleRecent(t *testing.T) {
 	tg := &mockTelegram{}
 	repo := &mockRepo{results: []db.Result{{ID: 1}, {ID: 2}}}
-	docsBaseURL = "http://d"
+	t.Setenv("DOCS_BASE_URL", "http://d")
+	docsBaseURL = loadDocsBaseURL()
 	if err := handleRecent(context.Background(), tg, repo, 10); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- read `DOCS_BASE_URL` at start with fallback to `https://example.com/docs`
- allow tests to override this value
- document the variable in README and `.env.example`

## Testing
- `go test ./... -run TestHandleRecent -count=1`
- `go test ./... -count=1`

------
https://chatgpt.com/codex/tasks/task_e_683b320e42cc8328897a01f7f0ec60ba